### PR TITLE
Multistore - no storeCode in URL

### DIFF
--- a/router/beforeEach.ts
+++ b/router/beforeEach.ts
@@ -3,7 +3,8 @@ import rootStore from '@vue-storefront/core/store'
 import config from 'config'
 import {storeCodeFromRoute} from '@vue-storefront/core/lib/multistore'
 
-export function beforeEach (to: Route, from: Route, next) {
+export function beforeEach(to: Route, from: Route, next) {
+
   const cartToken: string = rootStore.state.cart.cartServerToken;
   const userToken: string = rootStore.state.user.token;
   const externalCheckoutConfig = {...config.externalCheckout};
@@ -15,6 +16,8 @@ export function beforeEach (to: Route, from: Route, next) {
   if (multistoreEnabled) {
     if (storeCode in stores && to.name === storeCode + '-checkout') {
       window.location.replace(stores[storeCode].cmsUrl + '/vue/cart/sync/token/' + userToken + '/cart/' + cartToken)
+    } else if (to.name === 'checkout') {
+      window.location.replace(stores[config.defaultStoreCode].cmsUrl + '/vue/cart/sync/token/' + userToken + '/cart/' + cartToken)
     } else {
       next()
     }

--- a/router/beforeEach.ts
+++ b/router/beforeEach.ts
@@ -1,7 +1,7 @@
 import {Route} from 'vue-router'
 import rootStore from '@vue-storefront/core/store'
 import config from 'config'
-import {storeCodeFromRoute} from '@vue-storefront/core/lib/multistore'
+import {currentStoreView} from '@vue-storefront/core/lib/multistore'
 
 export function beforeEach(to: Route, from: Route, next) {
 
@@ -10,14 +10,14 @@ export function beforeEach(to: Route, from: Route, next) {
   const externalCheckoutConfig = {...config.externalCheckout};
   const cmsUrl: string = externalCheckoutConfig.cmsUrl;
   const stores = externalCheckoutConfig.stores;
-  const storeCode = storeCodeFromRoute(to)
+  const storeCode = currentStoreView().storeCode
   const multistoreEnabled: boolean = config.storeViews.multistore
 
   if (multistoreEnabled) {
     if (storeCode in stores && to.name === storeCode + '-checkout') {
       window.location.replace(stores[storeCode].cmsUrl + '/vue/cart/sync/token/' + userToken + '/cart/' + cartToken)
-    } else if (to.name === 'checkout') {
-      window.location.replace(stores[config.defaultStoreCode].cmsUrl + '/vue/cart/sync/token/' + userToken + '/cart/' + cartToken)
+    } else if (storeCode in stores && to.name === 'checkout' && stores[storeCode].cmsUrl !== undefined) {
+      window.location.replace(stores[storeCode].cmsUrl + '/vue/cart/sync/token/' + userToken + '/cart/' + cartToken)
     } else {
       next()
     }


### PR DESCRIPTION
This change would handle the case in which your Multistore doesn't use the storeCode in the URL for the main store.